### PR TITLE
fix(panel): save word without confirm

### DIFF
--- a/src/content/components/WordEditor/WordEditorPanel.tsx
+++ b/src/content/components/WordEditor/WordEditorPanel.tsx
@@ -226,7 +226,7 @@ export const WordEditorPanel: FC<WordEditorPanelProps> = props => {
           className="wordEditor-Note_BtnSave"
           onClick={() =>
             saveWord('notebook', word)
-              .then(closeEditor)
+              .then(props.onClose)
               .catch(console.error)
           }
         >


### PR DESCRIPTION
保存到生词本时，修改了笔记，再点保存按钮会弹『记录尚未保存，确认关闭』对话框。

这里似乎不需要提示未保存？