### PR TITLE
fix(fixtures): read url of undefined

### DIFF
--- a/scripts/fixtures.js
+++ b/scripts/fixtures.js
@@ -130,7 +130,6 @@ async function add() {
         continue
       }
 
-      const { origin, host } = new URL(customConfig.url)
 
       if (!customConfig) {
         pgBar.update(null, { status: 'empty config' })
@@ -138,6 +137,7 @@ async function add() {
         continue
       }
 
+      const { origin, host } = new URL(customConfig.url)
       const axiosConfig = {
         transformResponse: [data => data],
         ...proxyConfig,


### PR DESCRIPTION
When I run `yarn fixtures` always get `can not read url of undefined` error, this is my fix.