### PR TITLE
feat(no-typefield): add support for content editable

### DIFF
--- a/src/selection/helper.ts
+++ b/src/selection/helper.ts
@@ -49,6 +49,10 @@ export function isTypeField(element: Node | EventTarget | null): boolean {
       return true
     }
 
+    if (el instanceof HTMLElement && el.isContentEditable) {
+      return true
+    }
+
     // With CodeMirror the `pre.CodeMirror-line` somehow got detached when the event
     // triggerd. So el will never reach the root `.CodeMirror`.
     if (editorTester.test(String(el.className))) {


### PR DESCRIPTION
Hello,
I turned on `no-type field` option, but it seems not work for Notion.

![image](https://user-images.githubusercontent.com/35420264/119483051-2aba0200-bd87-11eb-9109-fb015a4ab7f4.png)

ref: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/contentEditable

I don't know whether this change will work, this might need some tests.