### PR TITLE
fix(dict-panel): fix default pinned

### DIFF
--- a/src/content/redux/modules/action-handlers/new-selection.ts
+++ b/src/content/redux/modules/action-handlers/new-selection.ts
@@ -88,7 +88,7 @@ export const newSelection: ActionHandler<
   const { direct, holding, double, icon } = config.mode
 
   newState.isShowDictPanel = Boolean(
-    state.isPinned ||
+    (state.isPinned && state.isShowDictPanel) ||
       (isActive &&
         selection.word &&
         selection.word.text &&


### PR DESCRIPTION
上次的PR是有问题的，打开以后虽然会自动 pin 住但是会在每个页面自动显示面板，正确的行为是第一次查词的时候 pin 住。

这个 PR 能修复这个问题，但遗留一个问题是开了选项以后第一次选中词，图标的出现在左上角。问题可能出在[这里](https://github.com/uonr/ext-saladict/blob/df43b85ffe87b0e7743354a854fb4537cb7130c1/src/content/redux/modules/action-handlers/new-selection.ts#L32)，这里的判断如果是 pin 状态就不会计算坐标。而开启选项了以后默认状态就是 pin。

我尝试修复但是失败了，而且这个问题并不严重，默认固定住的话不会很在意初始位置，比之前完全 broken 好。