### PR TITLE
fix: correct regex of locating default pdf

### DIFF
--- a/scripts/pdf.js
+++ b/scripts/pdf.js
@@ -66,7 +66,7 @@ async function modifyViewrJS() {
   file = '/* saladict */ window.__SALADICT_PDF_PAGE__ = true;\n' + file
 
   // change default pdf
-  const defaultPDFTester = /defaultUrl: {[\s\S]*?value: (['"]\S+?.pdf['"]),[\s\S]*?kind: OptionKind\.VIEWER/
+  const defaultPDFTester = /defaultUrl = {[\s\S]*?value: (['"]\S+?.pdf['"]),[\s\S]*?kind: OptionKind\.VIEWER/
   if (!defaultPDFTester.test(file)) {
     shell.echo('Could not locate default pdf in viewer.js')
     shell.exit(1)


### PR DESCRIPTION
I would like to build saladict from source and encountered an error when executing `yarn pdf`.

```
Could not locate default pdf in viewer.js
```

This error may be due to upstream changes.

```
defaultOptions.defaultUrl = {
    value: "compressed.tracemonkey-pldi-09.pdf",
    kind: OptionKind.VIEWER
  };
```

I'm not sure whether my change is appropriote. Maybe upstream may changes someday later. I think a better solution maybe use `git submodule`?