### PR TITLE
fix: 移除谷歌翻译cn

### DIFF
--- a/src/components/dictionaries/google/config.ts
+++ b/src/components/dictionaries/google/config.ts
@@ -13,7 +13,6 @@ export type GoogleLanguage = Subunion<
 export type GoogleConfig = MachineDictItem<
   GoogleLanguage,
   {
-    cnfirst: boolean
     concurrent: boolean
   }
 >
@@ -23,7 +22,6 @@ export default (): GoogleConfig =>
     ['zh-CN', 'zh-TW', 'en', 'ja', 'ko', 'fr', 'de', 'es', 'ru', 'nl'],
     {},
     {
-      cnfirst: true,
       concurrent: false
     },
     {}

--- a/src/components/dictionaries/google/engine.ts
+++ b/src/components/dictionaries/google/engine.ts
@@ -13,7 +13,7 @@ import { Language } from '@opentranslate/languages'
 export const getTranslator = memoizeOne(() => new Google({ env: 'ext' }))
 
 export const getSrcPage: GetSrcPageFunction = (text, config, profile) => {
-  const domain = profile.dicts.all.google.options.cnfirst ? 'cn' : 'com'
+  const domain = 'com'
   const lang =
     profile.dicts.all.google.options.tl === 'default'
       ? config.langCode
@@ -44,7 +44,6 @@ export const search: SearchFunction<
     const result = await translator.translate(text, sl, tl, {
       token: process.env.GOOGLE_TOKEN || '',
       concurrent: options.concurrent,
-      order: options.cnfirst ? ['cn', 'com'] : ['com', 'cn'],
       apiAsFallback: true
     })
     return machineResult(


### PR DESCRIPTION
2022年9月30日,谷歌停止了谷歌翻译cn服务