### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Saladict 沙拉查词
 
 [![Version](https://img.shields.io/github/release/crimx/ext-saladict.svg?label=version)](https://github.com/crimx/ext-saladict/releases)
-[![Chrome Web Store](https://badgen.net/chrome-web-store/users/cdonnmffkdaoajfknoeeecmchibpmkmg?icon=chrome&color=0f9d58)](https://chrome.google.com/webstore/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
-[![Chrome Web Store](https://badgen.net/chrome-web-store/stars/cdonnmffkdaoajfknoeeecmchibpmkmg?icon=chrome&color=0f9d58)](https://chrome.google.com/webstore/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
+[![Chrome Web Store](https://badgen.net/chrome-web-store/users/cdonnmffkdaoajfknoeeecmchibpmkmg?icon=chrome&color=0f9d58)](https://chromewebstore.google.com/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
+[![Chrome Web Store](https://badgen.net/chrome-web-store/stars/cdonnmffkdaoajfknoeeecmchibpmkmg?icon=chrome&color=0f9d58)](https://chromewebstore.google.com/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
 [![Mozilla Add-on](https://badgen.net/amo/users/ext-saladict?icon=firefox&color=ff9500)](https://addons.mozilla.org/firefox/addon/ext-saladict/)
 [![Mozilla Add-on](https://badgen.net/amo/stars/ext-saladict?icon=firefox&color=ff9500)](https://addons.mozilla.org/firefox/addon/ext-saladict/)
 
@@ -21,7 +21,7 @@ Chrome/Firefox WebExtension. Feature-rich inline translator with PDF support.
 
 ## Downloads
 
-- [Chrome Web Store](https://chrome.google.com/webstore/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
+- [Chrome Web Store](https://chromewebstore.google.com/detail/cdonnmffkdaoajfknoeeecmchibpmkmg?hl=en)
 - [Firefox Add-ons](https://addons.mozilla.org/firefox/addon/ext-saladict/)
 - [Microsoft Edge Addons](https://microsoftedge.microsoft.com/addons/detail/idghocbbahafpfhjnfhpbfbmpegphmmp)(Uploaded by @rumosky)
 - See [releases](https://github.com/crimx/ext-saladict/releases) for more.


### PR DESCRIPTION
## Summary

- Updated 3 Chrome Web Store URLs in README.md from `chrome.google.com/webstore` to `chromewebstore.google.com`
- Google migrated the Chrome Web Store to a new domain; the old URLs now redirect

## Details

The Chrome Web Store moved to `chromewebstore.google.com`. The old `chrome.google.com/webstore` URLs still redirect, but it's better to link directly to the canonical domain.

**URLs updated:**
- Badge link (users count)
- Badge link (stars count)
- Downloads section link